### PR TITLE
카카오 로그인을 위한 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+  implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/ssacation/ssacation/oauth/OAuthController.java
+++ b/src/main/java/com/ssacation/ssacation/oauth/OAuthController.java
@@ -1,0 +1,43 @@
+package com.ssacation.ssacation.oauth;
+
+import java.util.HashMap;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.AllArgsConstructor;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/oauth")
+public class OAuthController {
+
+  private final OAuthService oAuthService;
+  /**
+   * 카카오 callback
+   * [GET] /oauth/kakao/callback
+   */
+  @ResponseBody
+  @GetMapping("/kakao")
+  public ResponseEntity<HashMap<String, Object>> kakaoCallback(@RequestParam String code) {
+
+    System.out.println(code);
+    String accessToken = oAuthService.getKakaoAccessToken(code);
+    HashMap<String, Object> userInfo = null;
+
+    try {
+
+      userInfo = oAuthService.getUserInfo(accessToken);
+
+    } catch (Throwable e) {
+      
+      e.printStackTrace();
+    }
+    return new ResponseEntity<>(userInfo, HttpStatus.OK);
+  }
+}

--- a/src/main/java/com/ssacation/ssacation/oauth/OAuthController.java
+++ b/src/main/java/com/ssacation/ssacation/oauth/OAuthController.java
@@ -1,8 +1,5 @@
 package com.ssacation.ssacation.oauth;
 
-import java.util.HashMap;
-
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,20 +21,14 @@ public class OAuthController {
    */
   @ResponseBody
   @GetMapping("/kakao")
-  public ResponseEntity<HashMap<String, Object>> kakaoCallback(@RequestParam String code) {
+  public ResponseEntity<Object> kakaoCallback(@RequestParam String code) {
 
-    System.out.println(code);
+    // accessToken 발급받기
     String accessToken = oAuthService.getKakaoAccessToken(code);
-    HashMap<String, Object> userInfo = null;
 
-    try {
+    // userInfo 받아오기
+    Object userInfo = oAuthService.getUserInfo(accessToken);
 
-      userInfo = oAuthService.getUserInfo(accessToken);
-
-    } catch (Throwable e) {
-      
-      e.printStackTrace();
-    }
-    return new ResponseEntity<>(userInfo, HttpStatus.OK);
+    return ResponseEntity.ok(userInfo);
   }
 }

--- a/src/main/java/com/ssacation/ssacation/oauth/OAuthService.java
+++ b/src/main/java/com/ssacation/ssacation/oauth/OAuthService.java
@@ -1,15 +1,13 @@
 package com.ssacation.ssacation.oauth;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,118 +15,91 @@ import java.util.Map;
 @Service
 public class OAuthService {
 
-  // 카카오 서버로 부터 Access 토큰값 받아오기 (Front 없이 로그인 기능 테스트용)
+  String clientId = "5751a58d2e844ce9688d9a20b2fffd60";
+
+  // 카카오 서버로 부터 Access 토큰값 받아오기
   public String getKakaoAccessToken(String code) {
-    String access_Token = "";
-    String refresh_Token = "";
-    String reqURL = "https://kauth.kakao.com/oauth/token";
 
-    try {
-      URL url = new URL(reqURL);
-      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    String kakaoAuthUrl = "https://kauth.kakao.com";
+    WebClient kakaoWebClient = WebClient.builder()
+        .baseUrl(kakaoAuthUrl)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build();
 
-      // POST 요청을 위해 기본값이 false인 setDoOutput을 true
-      conn.setRequestMethod("POST");
-      conn.setDoOutput(true);
+    // 카카오 Auth API 호출
+    @SuppressWarnings("unchecked")
+    Map<String, Object> tokenResponse = kakaoWebClient
+        .post()
+        .uri(uriBuilder -> uriBuilder
+            .path("/oauth/token")
+            .queryParam("grant_type", "authorization_code")
+            .queryParam("client_id", clientId)
+            .queryParam("code", code)
+            .build())
+        .retrieve()
+        .bodyToMono(Map.class)
+        .block();
 
-      // POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
-      BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
-      StringBuilder sb = new StringBuilder();
-      sb.append("grant_type=authorization_code");
-      sb.append("&client_id=5751a58d2e844ce9688d9a20b2fffd60"); // TODO REST_API_KEY 입력
-      sb.append("&redirect_uri=http://localhost:8080/oauth/kakao"); // TODO 인가코드 받은 redirect_uri 입력
-      sb.append("&code=" + code);
-      bw.write(sb.toString());
-      bw.flush();
-
-      // 결과 코드가 200이라면 성공
-      int responseCode = conn.getResponseCode();
-      log.info("responseCode : " + responseCode);
-
-      // 요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
-      BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-      String line = "";
-      String result = "";
-
-      while ((line = br.readLine()) != null) {
-        result += line;
-      }
-      log.info("response body : " + result);
-
-      // Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
-      ObjectMapper objectMapper = new ObjectMapper();
-      Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {});
-
-      access_Token = jsonMap.get("access_token").toString();
-			refresh_Token = jsonMap.get("refresh_token").toString();
-
-			log.info("access_token : " + access_Token);
-			log.info("refresh_token : " + refresh_Token);
-
-      br.close();
-      bw.close();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-
-    return access_Token;
+    String accessToken = (String) tokenResponse.get("access_token");
+    log.info("accessToken : " + accessToken);
+    return accessToken;
   }
 
   // 액세스 토큰으로 카카오 서버에서 유저 정보 받아오기
-  public HashMap<String, Object> getUserInfo(String access_Token) throws Throwable {
-		// 요청하는 클라이언트마다 가진 정보가 다를 수 있기에 HashMap타입으로 선언
-		HashMap<String, Object> userInfo = new HashMap<String, Object>();
-		String reqURL = "https://kapi.kakao.com/v2/user/me";
+  public Object getUserInfo(String accessToken) {
 
-		try {
-			URL url = new URL(reqURL);
-			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-			conn.setRequestMethod("GET");
+    String kakaoApiUrl = "https://kapi.kakao.com";
+    // webClient 설정
+    WebClient kakaoApiWebClient = WebClient.builder()
+        .baseUrl(kakaoApiUrl)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build();
 
-			// 요청에 필요한 Header에 포함될 내용
-			conn.setRequestProperty("Authorization", "Bearer " + access_Token);
+    // 카카오 Info API 설정
+    @SuppressWarnings("unchecked")
+    Map<String, Object> infoResponse = kakaoApiWebClient
+        .post()
+        .uri(uriBuilder -> uriBuilder
+            .path("/v2/user/me")
+            .build())
+        .header("Authorization", "Bearer " + accessToken)
+        .retrieve()
+        .bodyToMono(Map.class)
+        .block();
 
-			int responseCode = conn.getResponseCode();
-			log.info("responseCode : " + responseCode);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> kakaoAccountMap = (Map<String, Object>) infoResponse.get("kakao_account");
+    @SuppressWarnings("unchecked")
+    Map<String, String> profileMap = (Map<String, String>) kakaoAccountMap.get("profile");
+    HashMap<String, Object> responseMap = new HashMap<>();
 
-			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(),"UTF-8"));
+    // 닉네임 정보 담기
+    if (StringUtils.hasText(profileMap.get("nickname"))) {
+      responseMap.put("nickname", profileMap.get("nickname"));
+    }
+    // 프로필 사진 정보 담기
+    if (StringUtils.hasText(profileMap.get("profile_image_url"))) {
+      responseMap.put("profileImageUrl", profileMap.get("profile_image_url"));
+    }
+    // 이메일 정보 담기
+    if ("true".equals(kakaoAccountMap.get("has_email").toString())) {
+      responseMap.put("email", kakaoAccountMap.get("email").toString());
+    }
+    // 성별 정보 담기
+    if ("true".equals(kakaoAccountMap.get("has_gender").toString())) {
+      responseMap.put("gender", kakaoAccountMap.get("gender").toString());
+    }
+    // 연령대 정보 담기
+    if ("true".equals(kakaoAccountMap.get("has_age_range").toString())) {
+      responseMap.put("ageRange", kakaoAccountMap.get("age_range").toString());
+    }
+    // 생일 정보 담기
+    if ("true".equals(kakaoAccountMap.get("has_birthday").toString())) {
+      responseMap.put("birthday", kakaoAccountMap.get("birthday").toString());
+    }
 
-			String line = "";
-			String result = "";
-
-			while ((line = br.readLine()) != null) {
-				result += line;
-			}
-
-			log.info("response body : " + result);
-			log.info("result type" + result.getClass().getName()); // java.lang.String
-
-			try {
-				// jackson objectmapper 객체 생성
-				ObjectMapper objectMapper = new ObjectMapper();
-				// JSON String -> Map
-				Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {});
-
-				System.out.println(jsonMap.get("properties"));
-
-				Map<String, Object> properties = (Map<String, Object>) jsonMap.get("properties");
-				Map<String, Object> kakao_account = (Map<String, Object>) jsonMap.get("kakao_account");
-
-				String nickname = properties.get("nickname").toString();
-				String email = kakao_account.get("email").toString();
-
-				userInfo.put("nickname", nickname);
-				userInfo.put("email", email);
-
-			} catch (Exception e) {
-
-				e.printStackTrace();
-			}
-		} catch (IOException e) {
-
-			e.printStackTrace();
-		}
-		return userInfo;
-	}
-  
+    // 결과 반환
+    log.info("kakaoAccountMap : " + kakaoAccountMap);
+    return responseMap;
+  }
 }

--- a/src/main/java/com/ssacation/ssacation/oauth/OAuthService.java
+++ b/src/main/java/com/ssacation/ssacation/oauth/OAuthService.java
@@ -1,0 +1,134 @@
+package com.ssacation.ssacation.oauth;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class OAuthService {
+
+  // 카카오 서버로 부터 Access 토큰값 받아오기 (Front 없이 로그인 기능 테스트용)
+  public String getKakaoAccessToken(String code) {
+    String access_Token = "";
+    String refresh_Token = "";
+    String reqURL = "https://kauth.kakao.com/oauth/token";
+
+    try {
+      URL url = new URL(reqURL);
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+      // POST 요청을 위해 기본값이 false인 setDoOutput을 true
+      conn.setRequestMethod("POST");
+      conn.setDoOutput(true);
+
+      // POST 요청에 필요로 요구하는 파라미터 스트림을 통해 전송
+      BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+      StringBuilder sb = new StringBuilder();
+      sb.append("grant_type=authorization_code");
+      sb.append("&client_id=5751a58d2e844ce9688d9a20b2fffd60"); // TODO REST_API_KEY 입력
+      sb.append("&redirect_uri=http://localhost:8080/oauth/kakao"); // TODO 인가코드 받은 redirect_uri 입력
+      sb.append("&code=" + code);
+      bw.write(sb.toString());
+      bw.flush();
+
+      // 결과 코드가 200이라면 성공
+      int responseCode = conn.getResponseCode();
+      log.info("responseCode : " + responseCode);
+
+      // 요청을 통해 얻은 JSON타입의 Response 메세지 읽어오기
+      BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+      String line = "";
+      String result = "";
+
+      while ((line = br.readLine()) != null) {
+        result += line;
+      }
+      log.info("response body : " + result);
+
+      // Gson 라이브러리에 포함된 클래스로 JSON파싱 객체 생성
+      ObjectMapper objectMapper = new ObjectMapper();
+      Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {});
+
+      access_Token = jsonMap.get("access_token").toString();
+			refresh_Token = jsonMap.get("refresh_token").toString();
+
+			log.info("access_token : " + access_Token);
+			log.info("refresh_token : " + refresh_Token);
+
+      br.close();
+      bw.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return access_Token;
+  }
+
+  // 액세스 토큰으로 카카오 서버에서 유저 정보 받아오기
+  public HashMap<String, Object> getUserInfo(String access_Token) throws Throwable {
+		// 요청하는 클라이언트마다 가진 정보가 다를 수 있기에 HashMap타입으로 선언
+		HashMap<String, Object> userInfo = new HashMap<String, Object>();
+		String reqURL = "https://kapi.kakao.com/v2/user/me";
+
+		try {
+			URL url = new URL(reqURL);
+			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+			conn.setRequestMethod("GET");
+
+			// 요청에 필요한 Header에 포함될 내용
+			conn.setRequestProperty("Authorization", "Bearer " + access_Token);
+
+			int responseCode = conn.getResponseCode();
+			log.info("responseCode : " + responseCode);
+
+			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(),"UTF-8"));
+
+			String line = "";
+			String result = "";
+
+			while ((line = br.readLine()) != null) {
+				result += line;
+			}
+
+			log.info("response body : " + result);
+			log.info("result type" + result.getClass().getName()); // java.lang.String
+
+			try {
+				// jackson objectmapper 객체 생성
+				ObjectMapper objectMapper = new ObjectMapper();
+				// JSON String -> Map
+				Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {});
+
+				System.out.println(jsonMap.get("properties"));
+
+				Map<String, Object> properties = (Map<String, Object>) jsonMap.get("properties");
+				Map<String, Object> kakao_account = (Map<String, Object>) jsonMap.get("kakao_account");
+
+				String nickname = properties.get("nickname").toString();
+				String email = kakao_account.get("email").toString();
+
+				userInfo.put("nickname", nickname);
+				userInfo.put("email", email);
+
+			} catch (Exception e) {
+
+				e.printStackTrace();
+			}
+		} catch (IOException e) {
+
+			e.printStackTrace();
+		}
+		return userInfo;
+	}
+  
+}

--- a/src/main/java/com/ssacation/ssacation/user/UserService.java
+++ b/src/main/java/com/ssacation/ssacation/user/UserService.java
@@ -29,14 +29,14 @@ public class UserService {
    */
   public UserEntity createUser(UserEntity model) {
     UserEntity creatededUser = null;
-    try {
+    // try {
       Optional<UserEntity> existUser = getUser(model.getId());
       if (ObjectUtils.isEmpty(existUser)) {
         creatededUser = userRepository.save(model);
       }
-    } catch (Exception e) {
-      log.info("[Fail] e: " + e.toString());
-    }
+    // } catch (Exception e) {
+    //   log.info("[Fail] e: " + e.toString());
+    // }
     return creatededUser;
   }
 


### PR DESCRIPTION
# 📠 작업 로그

💡 **클라이언트에서 `Access Token`을 보냈을 때, 이에 상응하는 회원가입과 로그인 서비스를 구현해보자!**

1. 카카오 Developers 사이트에서 어플리케이션 추가하기
**https://developers.kakao.com/docs/latest/ko/kakaologin/common**
2. 카카오 로그인 설정에서 활성화 설정을 한 후, Redirect URI를 백엔드 서버에서 응답받을 경로로 설정
3. 위에서 설정한 Redirect URI와 1번에서 생성된 REST API 키를 활용하여 로그인 주소 확인
`kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&redirect_uri={REDIRECT_URI}&response_type=code`
예시) https://kauth.kakao.com/oauth/authorize?client_id=5751a58d2e844ce9688d9a20b2fffd60&redirect_uri=http://localhost:8080/oauth/kakao&response_type=code
4. `oauth` 폴더에 `REDIRECT_URI` 로의 요청을 받을 `OAuthController` 와 카카오 API 서버로 부터 토큰과 유저 정보를 받아와서 신규 회원가입 요청이나 JWT를 반환하는 `OAuthService` 를 구현

# 🐞 디버깅 로그

## 👿 1 - 1. 카카오 API 유저 정보 인코딩 문제

```json
responseCode : 200
response body : {"id":2822608481,"connected_at":"2023-06-06T13:35:05Z","properties":{"nickname":"諛뺤 
쥌?샇"},"kakao_account":{"profile_nickname_needs_agreement":false,"profile":{"nickname":"諛뺤쥌?샇"},"has_email":true,"email_needs_agreement":false,"is_email_valid":true,"is_email_verified":true,"email":"pipi1119@naver.com","has_age_range":true,"age_range_needs_agreement":false,"age_range":"20~29","has_birthday":true,"birthday_needs_agreement":false,"birthday":"1119","birthday_type":"SOLAR"}}
result typejava.lang.String
{nickname=諛뺤쥌?샇}
```

**발급받은 토큰으로 유저 정보를 받는 것은 성공했으나, 한글로 된 유저 정보가 깨지는 현상**

## 🧑🏻‍💻 1 - 2. 위 버그를 해결한 방법

**응답 값을 읽는 `InputStreamReader()` 의 기본 인코딩 방식이 `UTF-16` 이므로 발생한 버그**

**인코딩 방식을 `UTF-8` 으로 명시해주면 해결가능**